### PR TITLE
Use netdata/netdata:v1.21.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/vshn/netdata-openshift:v1.19
+FROM docker.io/netdata/netdata:v1.21.0
 
 COPY netdata.conf python.d.conf /etc/netdata/


### PR DESCRIPTION
It should run on Openshift anyway since https://github.com/netdata/netdata/pull/6543 got merged, there's not a reason to use vshn/netdata-openshift anymore.

I have tested it with: `docker run --rm -it --user 1000:0 -p 19999:19999 local/netdata-web-log` and it starts up without problems.